### PR TITLE
Added 60dB integration

### DIFF
--- a/KALO_ESP32_Voice_Assistant/KALO_ESP32_Voice_Assistant_20250106.ino
+++ b/KALO_ESP32_Voice_Assistant/KALO_ESP32_Voice_Assistant_20250106.ino
@@ -30,18 +30,28 @@
 
 // --- PRIVATE credentials -----
 
-const char* ssid =        "...";          // ### INSERT your wlan ssid 
-const char* password =    "...";          // ### INSERT your password  
+const char* ssid =        "...";          // ### INSERT your wlan ssid
+const char* password =    "...";          // ### INSERT your password
 const char* OPENAI_KEY =  "...";          // ### INSERT your OpenAI key
- 
-// --- user preferences -------- 
+// (60db.ai API key + voice_id are defined in lib_60db.ino header)
+
+// --- user preferences --------
 
 #define AUDIO_FILE        "/Audio.wav"    // mandatory, filename for the AUDIO recording
 #define WELCOME_FILE      "/Welcome.wav"  // optionally, 'Hello' file will be played once on start (e.g. a gong or voice)
+#define TTS_60DB_FILE     "/tts_60db.wav" // temp file: 60db synthesized speech is decoded to SD here, then played
 
-#define TTS_GOOGLE_LANGUAGE   "en"        // needed for Google TTS voices only (not needed for multilingual OpenAI voices :) 
+#define TTS_GOOGLE_LANGUAGE   "en"        // needed for Google TTS voices only (not needed for multilingual OpenAI voices :)
                                           // examples: en-US, en-IN, en-BG, en-AU, nl-NL, nl-BE, de-DE, th-TH etc.
                                           // more infos: https://cloud.google.com/text-to-speech/docs/voices
+
+// --- Provider selection (run 60db 'along with' Deepgram, pick the active engine here) --------------------------------
+#define ENGINE_DEEPGRAM   1               // STT only
+#define ENGINE_OPENAI     2               // TTS only
+#define ENGINE_60DB       3               // STT + TTS (60db.ai)
+
+#define STT_ENGINE        ENGINE_60DB     // ### choose SpeechToText engine: ENGINE_DEEPGRAM or ENGINE_60DB
+#define TTS_ENGINE        ENGINE_60DB     // ### choose default speak-back engine: ENGINE_OPENAI or ENGINE_60DB
 
 // --- PIN assignments ---------
 
@@ -71,6 +81,10 @@ bool    Record_Available( String filename, float* audiolength_sec );
 
 String  SpeechToText_Deepgram( String filename );
 void    Deepgram_KeepAlive();
+
+String  SpeechToText_60db( String filename );                       // 60db.ai STT  (lib_60db.ino)
+String  TextToSpeech_60db( String text, String out_filename );      // 60db.ai TTS  (lib_60db.ino) -> returns SD path or ""
+void    Voices_60db();                                              // 60db.ai: optional, print your voice_id list
 
 
 
@@ -162,10 +176,14 @@ void loop()
         /*audio_play.connecttoFS(SD, AUDIO_FILE );              // play your own recorded audio  
         while (audio_play.isRunning()) {audio_play.loop();}     // wait here until done (just for Demo purposes)  */
         
-        // ## Demo 2 [SpeechToText] - Transcript the Audio (waiting here until done) 
-        led_RGB(HIGH,HIGH,LOW);  // BLUE means: 'Deepgram server creates transcription'
-        
-        String transcription = SpeechToText_Deepgram( AUDIO_FILE );  
+        // ## Demo 2 [SpeechToText] - Transcript the Audio (waiting here until done)
+        led_RGB(HIGH,HIGH,LOW);  // BLUE means: 'STT server creates transcription'
+
+        #if STT_ENGINE == ENGINE_60DB
+          String transcription = SpeechToText_60db( AUDIO_FILE );      // 60db.ai STT
+        #else
+          String transcription = SpeechToText_Deepgram( AUDIO_FILE );  // Deepgram STT
+        #endif
         
         led_RGB(HIGH,LOW,HIGH);  // GREEN means: 'Ready for recording'
         Serial.println(transcription);
@@ -224,13 +242,22 @@ void loop()
            // More info: https://platform.openai.com/docs/guides/text-to-speech/text-to-speech
            // keep in mind: OpenAI registration needed, enter your personal key in header #define OPENAI_KEY
     
-           // Demo example [by DEFAULT always]: .. speaking with an OpenAI voice (select one of the 6 voices by random)
+           // Demo example [by DEFAULT always]: .. speaking back the transcription with the selected TTS_ENGINE
+        #if TTS_ENGINE == ENGINE_60DB
+           // 60db.ai TTS: synthesize -> base64 WAV decoded to SD -> play via Audio.h (consistent with the record/play path)
+           Serial.println( "60db speaking: [" + transcription + "]" );
+           if ( TextToSpeech_60db( transcription, TTS_60DB_FILE ) != "" )
+           {  audio_play.connecttoFS( SD, TTS_60DB_FILE );   // non-blocking, played by audio_play.loop() at end of loop()
+           }
+        #else
+           // OpenAI TTS: 'human sounding' multilingual voices (select one of the 6 voices by random)
            String Voices[6] = { "alloy", "echo", "fable", "onyx", "nova", "shimmer" };
            int random_voice = random(6);
            Serial.println( "OpenAI '" + Voices[random_voice] + "' speaking: [" + transcription +"]");
-           
+
            // Play TTS OpenAI
-           audio_play.openai_speech(OPENAI_KEY, "tts-1", transcription.c_str(), Voices[random_voice], "mp3", "1");  
+           audio_play.openai_speech(OPENAI_KEY, "tts-1", transcription.c_str(), Voices[random_voice], "mp3", "1");
+        #endif
            
            
            // ## Demo 6 - Trigger any ESP32 actions via voice (example: say ".. give me a rainbow ..")

--- a/KALO_ESP32_Voice_Assistant/lib_60db.ino
+++ b/KALO_ESP32_Voice_Assistant/lib_60db.ino
@@ -1,0 +1,420 @@
+
+// ------------------------------------------------------------------------------------------------------------------------------
+// ----------------            KALO Library - 60db.ai SpeechToText + TextToSpeech with ESP32 & SD Card           ----------------
+// ----------------                                                                                              ----------------
+// ----------------   Mirrors the KALO Deepgram lib style (raw WiFiClientSecure, manual HTTP, json_object()).    ----------------
+// ----------------   Designed to run 'along with' Deepgram, selectable via #define toggle in the main sketch.   ----------------
+// ----------------                                                                                              ----------------
+// ----------------   STT  CALL: 'text  = SpeechToText_60db(SD_audio_file)'         [no Initialization needed]    ----------------
+// ----------------   TTS  CALL: 'wfile = TextToSpeech_60db(text, "/tts_60db.wav")' [returns SD path or ""]       ----------------
+// ----------------   Voices    : 'Voices_60db()'  (optional: prints your voice_id list to Serial)               ----------------
+// ----------------                                                                                              ----------------
+// ----------------   API docs: https://docs.60db.ai   |   Host: api.60db.ai:443   |   Auth: 'Bearer <key>'      ----------------
+// ------------------------------------------------------------------------------------------------------------------------------
+
+
+// --- includes ----------------
+
+#include <WiFiClientSecure.h>
+/* #include <SD.h>              // also needed, but already included in main.ino */
+
+
+// --- defines & macros --------
+
+#ifndef DEBUG                   // user can define favorite behaviour ('true' displays addition info)
+#  define DEBUG true            // <- define your preference here
+#  define DebugPrint(x);        if(DEBUG){Serial.print(x);}   /* do not touch */
+#  define DebugPrintln(x);      if(DEBUG){Serial.println(x);} /* do not touch */
+#endif
+
+
+// --- PRIVATE credentials -----
+
+const char* db60ApiKey =        "...";    // ### INSERT your 60db.ai API key (https://60db.ai)  (used as 'Bearer <key>')
+
+
+// --- user preferences --------
+
+#define DB60_VOICE_ID     ""    // ### INSERT a voice_id (UUID) from GET /myvoices, e.g. "7c32dd99-...". Empty = system default
+#define DB60_STT_LANGUAGE "en"  // ISO 639-1 code (e.g. "en", "de") forcing a language, or "auto" for 60db auto-detection
+#define TIMEOUT_60DB      20    // max waiting time [sec] for a 60db response (TTS synthesis can take a few seconds)
+
+
+// --- shared TLS client -------
+// Re-using the same global 'client' declared in lib_audio_transcription.ino (one TLS context, opened/closed per call).
+// Both STT and TTS here always client.stop() when done, so each call connects fresh to the correct host.
+
+extern WiFiClientSecure client;
+
+
+// helper declarations (defined further below)
+String  json_object( String input, String element );   // defined in lib_audio_transcription.ino (re-used here)
+
+
+
+// ##############################################################################################################################
+// ###  Small HTTP helpers (shared by STT + TTS): connect, read headers, de-chunk the response body                          ###
+// ##############################################################################################################################
+
+// Connect (TLS) to api.60db.ai if not already connected. Returns true on success.
+bool db60_connect()
+{
+  if ( client.connected() ) return true;
+  DebugPrintln("> Initialize 60db Server connection ... ");
+  client.setInsecure();
+  if (!client.connect("api.60db.ai", 443))
+  { Serial.println("\nERROR - WifiClientSecure connection to 60db Server failed!");
+    client.stop();
+    return false;
+  }
+  DebugPrintln("Done. Connected to 60db Server.");
+  return true;
+}
+
+
+// Reads the HTTP status line + headers (until the blank \r\n\r\n). Leaves the BODY untouched in the socket.
+// Fills 'headers' (raw header block), '*chunked' (Transfer-Encoding: chunked?) and '*content_len' (-1 if unknown).
+// Returns the numeric HTTP status code (e.g. 200), or -1 on timeout.
+int db60_read_headers( String &headers, bool *chunked, long *content_len, uint32_t deadline )
+{
+  headers = ""; *chunked = false; *content_len = -1;
+  while ( millis() < deadline )
+  { while ( client.available() )
+    { char c = client.read();
+      headers += c;
+      if ( headers.endsWith("\r\n\r\n") )           // end of header block reached
+      { String low = headers; low.toLowerCase();
+        *chunked = (low.indexOf("transfer-encoding: chunked") != -1);
+        int p = low.indexOf("content-length:");
+        if (p != -1) { *content_len = headers.substring(p+15, headers.indexOf('\n', p)).toInt(); }
+        int status = -1;
+        int sp = headers.indexOf(' ');              // "HTTP/1.1 200 OK" -> grab the number after first space
+        if (sp != -1) { status = headers.substring(sp+1, sp+5).toInt(); }
+        return status;
+      }
+    }
+    delay(2);
+  }
+  return -1;   // timeout
+}
+
+
+// Stateful body reader that transparently de-chunks 'Transfer-Encoding: chunked' responses.
+// Use: init once, then call next() repeatedly; it returns the next clean BODY byte, or -1 when the body is complete.
+struct db60_BodyReader
+{
+  bool     chunked;
+  long     content_len;     // -1 if unknown (read until socket closed)
+  long     body_seen;       // bytes returned so far (non-chunked accounting)
+  long     chunk_left;      // bytes remaining in current chunk (chunked accounting)
+  bool     done;
+  uint32_t deadline;
+
+  void init( bool _chunked, long _content_len, uint32_t _deadline )
+  { chunked = _chunked; content_len = _content_len; deadline = _deadline;
+    body_seen = 0; chunk_left = 0; done = false;
+  }
+
+  int wait_read()   // block (until deadline) for one raw socket byte; -1 on timeout/close
+  { while ( millis() < deadline )
+    { if ( client.available() ) return client.read();
+      if ( !client.connected() && !client.available() ) return -1;
+      delay(1);
+    }
+    return -1;
+  }
+
+  String read_line()   // read raw bytes until '\n' (used for chunk-size lines); trailing \r stripped
+  { String line = ""; int c;
+    while ( (c = wait_read()) != -1 ) { if (c == '\n') break; if (c != '\r') line += (char)c; }
+    return line;
+  }
+
+  int next()
+  { if (done) return -1;
+
+    if (!chunked)                                   // ---- plain body: honor Content-Length, else read until close
+    { if (content_len >= 0 && body_seen >= content_len) { done = true; return -1; }
+      int c = wait_read();
+      if (c == -1) { done = true; return -1; }
+      body_seen++;
+      return c;
+    }
+
+    // ---- chunked body: <hexsize>\r\n <data> \r\n ... 0\r\n\r\n
+    if (chunk_left == 0)
+    { String sz = read_line();
+      sz.trim();
+      if (sz.length() == 0) { sz = read_line(); sz.trim(); }   // tolerate a stray CRLF between chunks
+      chunk_left = strtol( sz.c_str(), NULL, 16 );
+      if (chunk_left == 0) { done = true; return -1; }          // last chunk
+    }
+    int c = wait_read();
+    if (c == -1) { done = true; return -1; }
+    chunk_left--;
+    if (chunk_left == 0) { read_line(); }                       // consume trailing CRLF after the chunk data
+    return c;
+  }
+};
+
+
+// Base64 symbol -> 6-bit value, or -1 for non-alphabet characters
+int db60_b64val( char c )
+{ if (c >= 'A' && c <= 'Z') return c - 'A';
+  if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+  if (c >= '0' && c <= '9') return c - '0' + 52;
+  if (c == '+') return 62;
+  if (c == '/') return 63;
+  return -1;
+}
+
+
+// Minimal JSON string escaper for the TTS 'text' field (quotes, backslash, common control chars)
+String db60_json_escape( String s )
+{ String out = "";
+  for (uint16_t i = 0; i < s.length(); i++)
+  { char c = s.charAt(i);
+    switch (c)
+    { case '\"': out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\n': out += "\\n";  break;
+      case '\r': out += "\\r";  break;
+      case '\t': out += "\\t";  break;
+      default:   out += c;
+    }
+  }
+  return out;
+}
+
+
+
+// ##############################################################################################################################
+// ###  SpeechToText  ->  POST /stt   (multipart/form-data: file=<wav>, language=<..>)   returns JSON { "text": ... }        ###
+// ##############################################################################################################################
+
+String SpeechToText_60db( String audio_filename )
+{
+  uint32_t t_start = millis();
+
+  // ---------- Connect to 60db Server (only if needed)
+  if ( !db60_connect() ) return ("");
+  uint32_t t_connected = millis();
+
+  // ---------- Check AUDIO file exists, get size
+  File audioFile = SD.open( audio_filename );
+  if (!audioFile) { Serial.println("ERROR - Failed to open file for reading"); return (""); }
+  size_t audio_size = audioFile.size();
+  audioFile.close();
+  DebugPrintln("> Audio File [" + audio_filename + "] found, size: " + (String) audio_size );
+
+  // ---------- flush any pending inbound bytes before a fresh request
+  while (client.available()) { client.read(); }
+
+  // ---------- Build the multipart/form-data envelope (head before the wav bytes, tail after)
+  String boundary = "----60dbESP32Boundary7f3Hd9KaLo";
+  String head = "--" + boundary + "\r\n"
+                "Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n"
+                "Content-Type: audio/wav\r\n\r\n";
+  String tail = "\r\n";
+  if ( String(DB60_STT_LANGUAGE) != "" )
+  { tail += "--" + boundary + "\r\n"
+            "Content-Disposition: form-data; name=\"language\"\r\n\r\n"
+            + String(DB60_STT_LANGUAGE) + "\r\n";
+  }
+  tail += "--" + boundary + "--\r\n";
+  size_t content_length = head.length() + audio_size + tail.length();
+
+  // ---------- Send HTTPS request header
+  client.println("POST /stt HTTP/1.1");
+  client.println("Host: api.60db.ai");
+  client.println("Authorization: Bearer " + String(db60ApiKey));
+  client.println("Content-Type: multipart/form-data; boundary=" + boundary);
+  client.println("Content-Length: " + String(content_length));
+  client.println("Connection: close");
+  client.println();                 // header complete
+
+  // ---------- Send body: multipart head, then wav bytes (in chunks), then multipart tail
+  client.print( head );
+  File file = SD.open( audio_filename, FILE_READ );
+  const size_t bufferSize = 1024;
+  uint8_t buffer[bufferSize];
+  size_t  bytesRead;
+  while (file.available())
+  { bytesRead = file.read(buffer, sizeof(buffer));
+    if (bytesRead > 0) { client.write(buffer, bytesRead); }
+  }
+  file.close();
+  client.print( tail );
+  DebugPrintln("> All bytes sent, waiting 60db transcription");
+  uint32_t t_bodysent = millis();
+
+  // ---------- Read response (headers + de-chunked body into a small String)
+  uint32_t deadline = millis() + TIMEOUT_60DB * 1000;
+  String headers; bool chunked; long clen;
+  int status = db60_read_headers( headers, &chunked, &clen, deadline );
+
+  String body = "";
+  db60_BodyReader rd; rd.init( chunked, clen, deadline );
+  for (int c; (c = rd.next()) != -1 && body.length() < 16000; ) { body += (char)c; }
+
+  client.stop();    // close (same reason as Deepgram lib: lets Audio.h re-use TLS afterwards)
+  uint32_t t_response = millis();
+
+  if (status != 200)
+  { Serial.println("\n*** 60db STT ERROR - HTTP status " + (String)status + " ***");
+    DebugPrintln("Response body: " + body);
+    return ("");
+  }
+
+  // ---------- Parse JSON: 60db transcript field is "text"
+  String transcription = json_object( body, "\"text\":" );
+
+  DebugPrintln( "---------------------------------------------------" );
+  DebugPrintln( "-> Latency CONNECT:        " + (String)((float)(t_connected-t_start)/1000) );
+  DebugPrintln( "-> Latency SENDING body:   " + (String)((float)(t_bodysent-t_connected)/1000) );
+  DebugPrintln( "-> Latency 60db response:  " + (String)((float)(t_response-t_bodysent)/1000) );
+  DebugPrintln( "=> TOTAL Duration [sec]: . " + (String)((float)(t_response-t_start)/1000) );
+  DebugPrintln( "=> HTTP status: " + (String)status + (chunked ? "  (chunked)" : "") );
+  DebugPrintln( "=> Transcription: [" + transcription + "]" );
+  DebugPrintln( "---------------------------------------------------\n" );
+
+  return transcription;
+}
+
+
+
+// ##############################################################################################################################
+// ###  TextToSpeech ->  POST /tts-synthesize  (JSON)  ->  base64 WAV streamed/decoded straight to an SD file                ###
+// ##############################################################################################################################
+// Returns the SD path of the written .wav on success (play it via audio_play.connecttoFS(SD, path)), or "" on error.
+
+String TextToSpeech_60db( String text, String out_filename )
+{
+  uint32_t t_start = millis();
+  if ( text == "" ) return ("");
+
+  // ---------- Connect to 60db Server (only if needed)
+  if ( !db60_connect() ) return ("");
+
+  // ---------- flush any pending inbound bytes
+  while (client.available()) { client.read(); }
+
+  // ---------- Build JSON payload (request WAV so it is directly playable by Audio.h, no transcoding needed)
+  String payload = "{";
+  payload += "\"text\":\"" + db60_json_escape(text) + "\",";
+  if ( String(DB60_VOICE_ID) != "" ) { payload += "\"voice_id\":\"" + String(DB60_VOICE_ID) + "\","; }
+  payload += "\"output_format\":\"wav\",";
+  payload += "\"enhance\":true,";
+  payload += "\"speed\":1,\"stability\":50,\"similarity\":75";
+  payload += "}";
+
+  // ---------- Send HTTPS request
+  client.println("POST /tts-synthesize HTTP/1.1");
+  client.println("Host: api.60db.ai");
+  client.println("Authorization: Bearer " + String(db60ApiKey));
+  client.println("Content-Type: application/json");
+  client.println("Content-Length: " + String(payload.length()));
+  client.println("Connection: close");
+  client.println();
+  client.print( payload );
+  DebugPrintln("> 60db TTS request sent, waiting & decoding audio ...");
+
+  // ---------- Read headers
+  uint32_t deadline = millis() + TIMEOUT_60DB * 1000;
+  String headers; bool chunked; long clen;
+  int status = db60_read_headers( headers, &chunked, &clen, deadline );
+
+  db60_BodyReader rd; rd.init( chunked, clen, deadline );
+
+  if (status != 200)
+  { String body = "";
+    for (int c; (c = rd.next()) != -1 && body.length() < 4000; ) { body += (char)c; }
+    client.stop();
+    Serial.println("\n*** 60db TTS ERROR - HTTP status " + (String)status + " ***");
+    DebugPrintln("Response body: " + body);
+    return ("");
+  }
+
+  // ---------- Prepare destination SD file
+  if ( SD.exists(out_filename) ) SD.remove(out_filename);
+  File out = SD.open(out_filename, FILE_WRITE);
+  if (!out) { client.stop(); Serial.println("ERROR - cannot create " + out_filename); return (""); }
+
+  // ---------- Phase 1: scan body until the marker  "audio_base64":"  (the prefix JSON is small)
+  const char* marker = "\"audio_base64\":\"";
+  String pre = ""; bool found = false;
+  for (int c; (c = rd.next()) != -1; )
+  { pre += (char)c;
+    if (pre.endsWith(marker)) { found = true; break; }
+    if (pre.length() > 4096) { pre = pre.substring(pre.length() - 32); }   // keep memory bounded while searching
+  }
+  if (!found)
+  { out.close(); SD.remove(out_filename); client.stop();
+    Serial.println("\n*** 60db TTS ERROR - 'audio_base64' not found in response ***");
+    return ("");
+  }
+
+  // ---------- Phase 2: stream base64 chars -> decode 4:3 -> write WAV bytes to SD (stop at closing quote)
+  uint8_t wbuf[512]; size_t wlen = 0;       // write buffer for SD performance
+  int     quad[4];   int qn = 0; int pad = 0;
+  long    audio_bytes = 0;
+  for (int c; (c = rd.next()) != -1; )
+  { if (c == '\"') break;                    // closing quote of the base64 string -> done
+    if (c == '\r' || c == '\n') continue;    // ignore whitespace/newlines inside the value
+    int v;
+    if (c == '=') { v = 0; pad++; }
+    else { v = db60_b64val((char)c); if (v < 0) continue; }
+    quad[qn++] = v;
+    if (qn == 4)
+    { uint8_t b0 = (quad[0] << 2) | (quad[1] >> 4);
+      uint8_t b1 = ((quad[1] & 0x0F) << 4) | (quad[2] >> 2);
+      uint8_t b2 = ((quad[2] & 0x03) << 6) | quad[3];
+      wbuf[wlen++] = b0; audio_bytes++;
+      if (pad < 2) { wbuf[wlen++] = b1; audio_bytes++; }
+      if (pad < 1) { wbuf[wlen++] = b2; audio_bytes++; }
+      if (wlen >= sizeof(wbuf) - 3) { out.write(wbuf, wlen); wlen = 0; }
+      qn = 0; pad = 0;
+    }
+  }
+  if (wlen > 0) { out.write(wbuf, wlen); }
+  out.close();
+  client.stop();
+
+  uint32_t t_done = millis();
+  DebugPrintln( "> 60db TTS done -> '" + out_filename + "', " + (String)audio_bytes
+                + " bytes, " + (String)((float)(t_done-t_start)/1000) + " sec" );
+
+  if (audio_bytes == 0) { SD.remove(out_filename); return (""); }
+  return out_filename;
+}
+
+
+
+// ##############################################################################################################################
+// ###  OPTIONAL: GET /myvoices  -> print your available voice_id list to Serial (run once to grab a voice_id UUID)          ###
+// ##############################################################################################################################
+
+void Voices_60db()
+{
+  if ( !db60_connect() ) return;
+  while (client.available()) { client.read(); }
+
+  client.println("GET /myvoices HTTP/1.1");
+  client.println("Host: api.60db.ai");
+  client.println("Authorization: Bearer " + String(db60ApiKey));
+  client.println("Connection: close");
+  client.println();
+
+  uint32_t deadline = millis() + TIMEOUT_60DB * 1000;
+  String headers; bool chunked; long clen;
+  int status = db60_read_headers( headers, &chunked, &clen, deadline );
+
+  String body = "";
+  db60_BodyReader rd; rd.init( chunked, clen, deadline );
+  for (int c; (c = rd.next()) != -1 && body.length() < 16000; ) { body += (char)c; }
+  client.stop();
+
+  DebugPrintln("---- 60db /myvoices (HTTP " + (String)status + ") ----");
+  DebugPrintln(body);
+  DebugPrintln("-------------------------------------------");
+}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 **... the libraries in this repository are outdated, you will find latest lib_xy() versions [here](https://github.com/kaloprojects/KALO-ESP32-Voice-Chat-AI-Friends)**
 
 # Summary
-Code snippets showing how to _record I2S audio_ and store as .wav file on ESP32 with SD card, how to _transcribe_ pre-recorded audio via _STT (SpeechToText)_ Deepgram API, how to _generate audio_ from text via _TTS (TextToSpeech)_ API from Google TTS or OpenAI TTS or (new) SpeechGen.IO. Triggering ESP32 actions via Voice.
+Code snippets showing how to _record I2S audio_ and store as .wav file on ESP32 with SD card, how to _transcribe_ pre-recorded audio via _STT (SpeechToText)_ Deepgram API or (new) 60db.ai API, how to _generate audio_ from text via _TTS (TextToSpeech)_ API from Google TTS or OpenAI TTS or SpeechGen.IO or (new) 60db.ai. Triggering ESP32 actions via Voice.
 
-The repository contains the Demo main sketch  'KALO_ESP32_Voice_Assistant.ino', demonstrating different use case of my libraries 'lib_audio_recording.ino', 'lib_audio_transcription.ino' and (new) 'lib_TTS_SpeechGen.ino' 
+The repository contains the Demo main sketch  'KALO_ESP32_Voice_Assistant.ino', demonstrating different use case of my libraries 'lib_audio_recording.ino', 'lib_audio_transcription.ino', 'lib_TTS_SpeechGen.ino' and (new) 'lib_60db.ino' 
 
 # Features
 Explore the demo use case examples in main sketch, summary:
@@ -14,9 +14,12 @@ Explore the demo use case examples in main sketch, summary:
 - Playing Audio streams (e.g. playing music via radio streams with <audio.h> library)
 - Triggering ESP actions via voice (e.g. triggering GPIO LED pins, addressing dedicated voices by calling their name, playing music on request)
 - STT (SpeechToText): Deepgram API service (registration needed)  
+- STT (SpeechToText): #NEW#: 60db.ai API service (registration needed)  
 - TTS (TextToSpeech): Google TTS free API (no registration needed)  
 - TTS (TextToSpeech): Open AI API (6 multilingual voices, registration needed)
-- TTS (TextToSpeech): #NEW#: SpeechGen.IO voices (many voices, not free, payment needed)  
+- TTS (TextToSpeech): SpeechGen.IO voices (many voices, not free, payment needed)  
+- TTS (TextToSpeech): #NEW#: 60db.ai voices (cloned & professional voices, registration needed)  
+- Provider selection: switch STT (Deepgram <-> 60db.ai) and default TTS (OpenAI <-> 60db.ai) via simple #define toggles  
 
 # Hardware
 - ESP32 development board (e.g. ESP32-WROOM-32), connected to Wifi
@@ -30,10 +33,21 @@ Explore the demo use case examples in main sketch, summary:
 - Required (for playing Audio on ESP32): AUDIO.H library [ESP32-audioI2S.zip](https://github.com/schreibfaul1/ESP32-audioI2S). Install latest zip (3.0.11g from July 18, 2024 or newer)
 - Copy all .ino files of 'KALO-ESP32-Voice-Assistant' into same folder (it is one sketch, split into multiple Arduino IDE tabs)
 - Update your pin assignments & wlan settings (ssid, password) in the .ino header files
-- Update headers with personal credentials (Deepgram API key, optional: OpenAI API key, SpeechGen Token)
+- Update headers with personal credentials (Deepgram API key, optional: OpenAI API key, SpeechGen Token, 60db.ai API key)
+- For 60db.ai: insert your API key + a voice_id (UUID) in lib_60db.ino header; run Voices_60db() once to list your voice_id's
+- Select the active engines in KALO_ESP32_Voice_Assistant.ino header: STT_ENGINE (ENGINE_DEEPGRAM/ENGINE_60DB) and TTS_ENGINE (ENGINE_OPENAI/ENGINE_60DB)
 - Define your favorite recording settings (SAMPLE_RATE, BITS_PER_SAMPLE, GAIN_BOOSTER_I2S) in lib_audio_recording.ino header
-- Define your language settings (Google TTS in KALO_ESP32_Voice_Assistant.ino, Deepgram STT in lib_audio_transcription.ino header)
+- Define your language settings (Google TTS in KALO_ESP32_Voice_Assistant.ino, Deepgram STT in lib_audio_transcription.ino header, 60db STT in lib_60db.ino header)
 - Toggle DEBUG flag to true (displaying Serial.print details) or false (for final usage)
+
+# 60db.ai integration (lib_60db.ino)
+The new 'lib_60db.ino' library mirrors the KALO Deepgram coding style (raw WiFiClientSecure, manual HTTPS, json_object() parser) so it runs 'along with' Deepgram, fully selectable via #define toggles. It adds both STT and TTS:
+- STT: `SpeechToText_60db(file)` -> `POST /stt` (multipart/form-data upload of the recorded .wav), parses the `"text"` field, returns the transcript
+- TTS: `TextToSpeech_60db(text, "/tts_60db.wav")` -> `POST /tts-synthesize` (output_format = wav). The Base64 audio is stream-decoded straight to the SD card (never buffered fully in RAM), then played via Audio.h `connecttoFS()`
+- Voices: `Voices_60db()` -> `GET /myvoices`, prints your available voice_id (UUID) list to Serial (run once to pick a voice)
+- Reliability: a small de-chunking reader transparently unwraps HTTP 'Transfer-Encoding: chunked' responses (from the 60db API gateway), so large Base64 TTS payloads decode cleanly
+- Host: api.60db.ai:443, Auth header: 'Bearer <api-key>'. API docs: https://docs.60db.ai
+- Note: 60db's streaming TTS (NDJSON /tts-stream) and WebSocket API are intentionally not used here (they don't fit the Audio.h playback model on ESP32); the synchronous /tts-synthesize path is used instead
 
 # Known issues
 - Earlier WifiClientSecure connection issues seem solved (with KALO 2025-01-06 Update & arduino-esp32 3.1.x)
@@ -41,6 +55,7 @@ Explore the demo use case examples in main sketch, summary:
 - TTS: Only OpenAI voices are multi-lingual (supporting multiple languages in same request), Google & SpeechGen.IO request language specific parameter/voices
 
 # Updates
+- 2026-06-12: NEW library 'lib_60db.ino' adding 60db.ai STT + TTS, running alongside Deepgram (selectable via #define toggle)
 - 2025-01-06: NEW library for TTS SpeechGen.IO (hundreds of voices) 
 - 2025-01-06: Cleaned code, connection reliability issues solved, response time improved
 - 2024-07-22: Misc. enhancements, WifiClientSecure reliability workarounds, code cleaned up


### PR DESCRIPTION
 Added 60db.ai (STT + TTS) to the ESP32 voice assistant, running alongside Deepgram.

  - New file lib_60db.ino with 3 functions:
    - SpeechToText_60db() — transcribes the recorded WAV via POST /stt
    - TextToSpeech_60db() — synthesizes speech via POST /tts-synthesize, decodes the audio to SD, plays it
    - Voices_60db() — lists your voice IDs via GET /myvoices
  - #define toggles in the main sketch to pick the engine: STT_ENGINE (Deepgram ↔ 60db) and TTS_ENGINE (OpenAI ↔ 60db).
  - Reliability handling — streams/Base64-decodes audio straight to SD (no RAM blowup) and de-chunks the HTTP responses.
  - README updated to document all of the above.

  Deepgram and the other TTS engines stay fully intact and selectable.